### PR TITLE
Patch/nil deref on bad depends-on config

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -19,7 +19,7 @@ It strives to reduce the number of terminal windows
 that need to be open.
 
 Config files live in ~/.config/oneterminal
-Run oneterminal example to generate an example config file`,
+Run "oneterminal example" to generate an example config file`,
 }
 
 // Execute the root command

--- a/internal/monitor/command.go
+++ b/internal/monitor/command.go
@@ -67,7 +67,12 @@ func (m *MonitoredCmd) Run() error {
 // Interrupt will send an interrupt signal to the process
 func (m *MonitoredCmd) Interrupt() {
 	if m.command.Process != nil {
-		m.command.Process.Signal(syscall.SIGINT)
+		// Note: if the underlying process does not handle interrupt signals,
+		// it will just keep running
+		err := m.command.Process.Signal(syscall.SIGINT)
+		if err != nil {
+			fmt.Printf("Error sending interrupt to %s: %v\n", m.name, err)
+		}
 	}
 }
 

--- a/internal/monitor/command.go
+++ b/internal/monitor/command.go
@@ -68,13 +68,18 @@ func (m *MonitoredCmd) Run() error {
 
 // Interrupt will send an interrupt signal to the process
 func (m *MonitoredCmd) Interrupt() {
-	if m.command.Process != nil {
-		// Note: if the underlying process does not handle interrupt signals,
-		// it will just keep running
-		err := m.command.Process.Signal(syscall.SIGINT)
-		if err != nil {
-			fmt.Printf("Error sending interrupt to %s: %v\n", m.name, err)
-		}
+	// Process has not started yet
+	if m.command.Process == nil || m.command.ProcessState == nil {
+		return
+	}
+	if m.command.ProcessState.Exited() {
+		return
+	}
+	// Note: if the underlying process does not handle interrupt signals,
+	// it will probably just keep running
+	err := m.command.Process.Signal(syscall.SIGINT)
+	if err != nil {
+		fmt.Printf("Error sending interrupt to %s: %v\n", m.name, err)
 	}
 }
 

--- a/internal/monitor/command.go
+++ b/internal/monitor/command.go
@@ -64,6 +64,8 @@ func (m *MonitoredCmd) Run() error {
 	return err
 }
 
+// TODO add RunContext method for another synchronization option
+
 // Interrupt will send an interrupt signal to the process
 func (m *MonitoredCmd) Interrupt() {
 	if m.command.Process != nil {

--- a/internal/monitor/orchestrator.go
+++ b/internal/monitor/orchestrator.go
@@ -3,7 +3,6 @@ package monitor
 import (
 	"errors"
 	"fmt"
-	"log"
 	"os"
 	"os/signal"
 	"sync"
@@ -109,7 +108,6 @@ func (orch *Orchestrator) SendInterrupts() {
 func checkDependencies(m *MonitoredCmd, allCmdsMap map[string]*MonitoredCmd) (bool, error) {
 	for _, depName := range m.dependsOn {
 		depCmd, ok := allCmdsMap[depName]
-		log.Println(depName, ok)
 		if !ok {
 			return false, errors.New(fmt.Sprintf("%q depends-on %q, but %q does not exist", m.name, depName, depName))
 		}

--- a/internal/monitor/orchestrator.go
+++ b/internal/monitor/orchestrator.go
@@ -62,6 +62,7 @@ func (orch *Orchestrator) RunCommands() {
 		go func() {
 			defer orch.wg.Done()
 			ticker := time.NewTicker(time.Millisecond * 200)
+			defer ticker.Stop()
 			// on every tick. check if entire orchestrator has been interrupted
 			// then check dependencies of of this command, run it if unblocked
 			for {
@@ -81,13 +82,14 @@ func (orch *Orchestrator) RunCommands() {
 					return
 				}
 				if canStart {
+					ticker.Stop() // safe to call twice?
 					err := cmd.Run()
-					// fmt.Println("ERROR FROM cmd.Run", err.Error())
 					if err != nil {
 						// TODO close the signalChan to send interrupts to other processes b/c a failed dependency should interrupt all other dependencies
 						// TODO add error messaging here if the err is from something other than an interrupt signal
 						// fmt.Printf("Error running %s: %v\n", cmd.name, err)
-						// close(signalChan)
+						fmt.Println(err)
+						close(signalChan)
 					}
 					break
 				}

--- a/internal/monitor/orchestrator.go
+++ b/internal/monitor/orchestrator.go
@@ -40,7 +40,7 @@ func (orch *Orchestrator) AddCommands(commands ...*MonitoredCmd) {
 // finished running. This can occur from the processes ending naturally
 // or being interrupted
 func (orch *Orchestrator) RunCommands() {
-	signalChan := make(chan os.Signal, 1)
+	signalChan := make(chan os.Signal)
 	signal.Notify(signalChan, syscall.SIGINT, syscall.SIGKILL, syscall.SIGTERM)
 
 	go func() {
@@ -89,7 +89,6 @@ func (orch *Orchestrator) RunCommands() {
 						// TODO add error messaging here if the err is from something other than an interrupt signal
 						// fmt.Printf("Error running %s: %v\n", cmd.name, err)
 						fmt.Println(err)
-						close(signalChan)
 					}
 					break
 				}


### PR DESCRIPTION
Resolves #3 

Root cause of issue: `monitored.checkDependencies(cmd, allCmdsMap)` could cause a nil pointer dereference panic if cmd depends on something that's not in the allCmdsMap. This PR errors gracefully if the dependent command is not found in the map.
