### PR TITLE
Adds update command

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ go get -u github.com/alexchao26/oneterminal
 ### From Github releases
 Alternatively, you can download the binary directly from the [Github releases](https://github.com/alexchao26/oneterminal/releases).
 
-Note that development was mostly on a Mac with `go version go1.15.6 darwin/amd` and some standard library packages (like [os/exec](https://golang.org/pkg/os/exec/)) do not have full support on Windows.
+Note that development was mostly on a Mac with `go version go1.16.2 darwin/amd64` and some standard library packages (like [os/exec](https://golang.org/pkg/os/exec/)) do not have full support on Windows.
 
 # Example Configurations
 
@@ -110,6 +110,7 @@ Command                                  | Description
 `oneterminal completion --help`          | Get helper text to setup shell completion for zsh or bash shells
 `oneterminal version`                    | Print the version number of oneterminal
 `oneterminal help`                       | Help about any command
+`oneterminal update`                     | Updates oneterminal to latest release
 `oneterminal <your-configured-commands>` | Your commands configured via ~/.config/oneterminal/*.yml
 
 # Contributing to oneterminal

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -43,6 +43,7 @@ Run "oneterminal example" to generate an example config file`,
 
 	rootCmd.AddCommand(ExampleCmd)
 	rootCmd.AddCommand(CompletionCmd)
+	rootCmd.AddCommand(makeUpdateCmd(version))
 	rootCmd.AddCommand(makeVersionCmd(version))
 
 	return rootCmd, nil

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -1,0 +1,105 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os/exec"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+func makeUpdateCmd(currentVersion string) *cobra.Command {
+	var dryRun, yesFlag bool
+
+	updateCmd := &cobra.Command{
+		Use:   "update",
+		Short: "Updates oneterminal to latest release",
+		Long: `Updates to the latest release using 'go install' as the pkg manager,
+so a local Go installation is required`,
+		// big ol' function
+		Run: func(_ *cobra.Command, _ []string) {
+			mostRecentVersion, err := getMostRecentVersion(currentVersion)
+			// non-critical error, continue w/ update after logging
+			if err != nil {
+				fmt.Println(err)
+			} else {
+				fmt.Printf("Most recent version is %s\n", mostRecentVersion)
+			}
+
+			if mostRecentVersion == "v"+currentVersion {
+				fmt.Println("Already up to date, Exiting.")
+				return
+			}
+
+			if dryRun {
+				fmt.Println("Exiting after dry run")
+				return
+			}
+
+			// Ask user if they want to continue with install
+			if !yesFlag {
+				var input string
+				fmt.Print("Continue with update? (y)es or (n)o: ")
+				fmt.Scanln(&input)
+				if input != "y" && input != "yes" {
+					fmt.Println("Exiting...")
+					return
+				}
+			}
+
+			// will error at c.Run if go is not installed locally
+			fmt.Println("Running `go install github.com/alexchao26/oneterminal@latest`")
+			c := exec.Command("go", "install", "github.com/alexchao26/oneterminal@latest")
+			if err := c.Run(); err != nil {
+				fmt.Println("Error:", err)
+				return
+			}
+			fmt.Println("Done.")
+		},
+	}
+
+	updateCmd.Flags().BoolVarP(&dryRun, "dryrun", "d", false, "just check Github for the latest release, do not install")
+	updateCmd.Flags().BoolVarP(&yesFlag, "yes", "y", false, "answer yes to all prompts")
+
+	return updateCmd
+}
+
+func getMostRecentVersion(currentVersion string) (string, error) {
+	fmt.Println("Checking for the latest release from Github...")
+	req, err := http.NewRequest("GET", "https://api.github.com/repos/alexchao26/oneterminal/releases?page=1", nil)
+	if err != nil {
+		return "", errors.Wrap(err, "Making Github request")
+	}
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", errors.Wrap(err, "Making Github request")
+	}
+	if resp.StatusCode != 200 {
+		return "", errors.Errorf("Bad response from Github %d", resp.StatusCode)
+	}
+
+	defer resp.Body.Close()
+	var githubResp []struct {
+		TagName string `json:"tag_name"`
+	}
+	err = json.NewDecoder(resp.Body).Decode(&githubResp)
+	if err != nil {
+		return "", errors.Wrap(err, "Decoding Github API Response")
+	}
+
+	var mostRecentVersion string
+	for _, release := range githubResp {
+		if release.TagName > mostRecentVersion {
+			mostRecentVersion = release.TagName
+		}
+	}
+
+	if mostRecentVersion == "" {
+		return "", errors.New("Didn't find any Github releases")
+	}
+	return mostRecentVersion, nil
+}

--- a/internal/yaml/yaml.go
+++ b/internal/yaml/yaml.go
@@ -87,6 +87,7 @@ func HasNameCollisions(configs []OneTerminalConfig) error {
 		"completion": true,
 		"example":    true,
 		"help":       true,
+		"update":     true,
 	}
 
 	allNames := make(map[string]bool)

--- a/oneterminal.go
+++ b/oneterminal.go
@@ -9,7 +9,7 @@ import (
 
 // variable is updated by goreleaser automatically but manually added here too
 // for manual/from source builds like `go get/install`
-var version = "0.3.3"
+var version = "0.3.4"
 
 func main() {
 	rootCmd, err := cli.Init(version)


### PR DESCRIPTION
`oneterminal update` checks Github's public REST API to find the most recent version for logging. Then builds from source via `go install github.com/alexchao26/oneterminal@latest`.

