### PR TITLE
allow .ya?ml extension, add `list` command, touch ups

### DIFF
--- a/cmdsync/cmd.go
+++ b/cmdsync/cmd.go
@@ -46,7 +46,7 @@ func NewShellCmd(shell, command string, options ...ShellCmdOption) (*ShellCmd, e
 		return nil, errors.Errorf("%q shell not supported. Use zsh|bash|sh", shell)
 	}
 
-	execCmd := exec.Command(shell, "-s", command)
+	execCmd := exec.Command(shell, "-c", command)
 	// inherit process group ID's so syscall.Kill reaches ALL child processes
 	// https://bigkevmcd.github.io/go/pgrp/context/2019/02/19/terminating-processes-in-go.html
 	execCmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}

--- a/cmdsync/cmd_test.go
+++ b/cmdsync/cmd_test.go
@@ -25,14 +25,14 @@ func init() {
 func TestMonitoredCmd_Run(t *testing.T) {
 	for name, tc := range map[string]struct {
 		command             string
-		commandOpts         []CmdOption
+		commandOpts         []ShellCmdOption
 		wantOutputToContain []string
 	}{
 		"echo Hello World": {"echo Hello, world!", nil, []string{"Hello, world!"}},
 		"go version":       {"go version", nil, []string{"go version"}},
 		"SetEnvironment Option": {
 			"echo $TEST_ENV_VAR",
-			[]CmdOption{
+			[]ShellCmdOption{
 				Environment(map[string]string{
 					"TEST_ENV_VAR": "beepboop",
 				}),
@@ -40,7 +40,7 @@ func TestMonitoredCmd_Run(t *testing.T) {
 	} {
 		closure := tc
 		t.Run(name, func(tt *testing.T) {
-			cmd, err := NewCmd(shell, closure.command, closure.commandOpts...)
+			cmd, err := NewShellCmd(shell, closure.command, closure.commandOpts...)
 			if err != nil {
 				t.Errorf("NewCmd() error want nil, got %v", err)
 			}

--- a/cmdsync/group.go
+++ b/cmdsync/group.go
@@ -5,15 +5,16 @@ import (
 	"os"
 	"os/signal"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
 )
 
-// Group manages scheduling concurrent Cmds
+// Group manages scheduling concurrent ShellCmds
 type Group struct {
-	commands   []*Cmd
+	commands   []*ShellCmd
 	hasStarted bool
 	mut        sync.RWMutex
 }
@@ -21,15 +22,15 @@ type Group struct {
 // NewGroup makes a new Group
 // it can be optionally initialized with commands
 // or they can be added later via AddCommands
-func NewGroup(commands ...*Cmd) *Group {
+func NewGroup(commands ...*ShellCmd) *Group {
 	return &Group{
 		commands: commands,
 	}
 }
 
-// AddCommands will add Cmds to the commands slice
+// AddCommands will add ShellCmds to the commands slice
 // It will return an error if called after Group.Run()
-func (g *Group) AddCommands(commands ...*Cmd) error {
+func (g *Group) AddCommands(commands ...*ShellCmd) error {
 	g.mut.Lock()
 	defer g.mut.Unlock()
 	if g.hasStarted {
@@ -39,19 +40,19 @@ func (g *Group) AddCommands(commands ...*Cmd) error {
 	return nil
 }
 
-// Run will run all of the group's Cmds and block until they have all finished
+// Run will run all of the group's ShellCmds and block until they have all finished
 // running, or an interrupt/kill signal is received, or the context cancels
 //
-// It checks for each Cmd's prerequisites (Cmds it depends-on being in a ready
-// state) before starting the Cmd
+// It checks for each ShellCmd's prerequisites (ShellCmds it depends-on being in a ready
+// state) before starting the ShellCmd
 //
-// The returned error is the first error returned from the Group's Cmds, if any
+// The returned error is the first error returned from the Group's ShellCmds, if any
 func (g *Group) Run(ctx context.Context) error {
 	g.mut.Lock()
 	g.hasStarted = true
 	g.mut.Unlock()
 
-	namesToCmds := make(map[string]*Cmd, len(g.commands))
+	namesToCmds := make(map[string]*ShellCmd, len(g.commands))
 	for _, cmd := range g.commands {
 		namesToCmds[cmd.name] = cmd
 	}
@@ -59,7 +60,7 @@ func (g *Group) Run(ctx context.Context) error {
 	eg, ctx := errgroup.WithContext(ctx)
 
 	signalChan := make(chan os.Signal)
-	signal.Notify(signalChan, os.Interrupt, os.Kill)
+	signal.Notify(signalChan, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
 		// events that could lead to a shutdown:
 		// 1. ctx is ended (from parent or errgroup Go routine returning non-nil error)
@@ -78,7 +79,7 @@ func (g *Group) Run(ctx context.Context) error {
 			ticker := time.NewTicker(time.Millisecond * 200)
 			defer ticker.Stop()
 			// on every tick, exit if context is done (shutdown has started)
-			// then start command if all depends-on Cmds' are in a ready state
+			// then start command if all depends-on ShellCmds' are in a ready state
 			for {
 				select {
 				case <-ctx.Done():
@@ -115,7 +116,7 @@ func (g *Group) SendInterrupts() {
 	}
 }
 
-func checkDependencies(cmd *Cmd, allCmdsMap map[string]*Cmd) (bool, error) {
+func checkDependencies(cmd *ShellCmd, allCmdsMap map[string]*ShellCmd) (bool, error) {
 	for _, depName := range cmd.dependsOn {
 		depCmd, ok := allCmdsMap[depName]
 		if !ok {

--- a/cmdsync/group.go
+++ b/cmdsync/group.go
@@ -41,13 +41,18 @@ func (g *Group) AddCommands(commands ...*ShellCmd) error {
 }
 
 // Run will run all of the group's ShellCmds and block until they have all finished
-// running, or an interrupt/kill signal is received, or the context cancels
+// running, or an interrupt/kill signal is received
 //
 // It checks for each ShellCmd's prerequisites (ShellCmds it depends-on being in a ready
 // state) before starting the ShellCmd
 //
 // The returned error is the first error returned from the Group's ShellCmds, if any
-func (g *Group) Run(ctx context.Context) error {
+func (g *Group) Run() error {
+	return g.RunContext(context.Background())
+}
+
+// RunContext is the same as Run but can also be cancelled via ctx
+func (g *Group) RunContext(ctx context.Context) error {
 	g.mut.Lock()
 	g.hasStarted = true
 	g.mut.Unlock()

--- a/color/color.go
+++ b/color/color.go
@@ -1,0 +1,46 @@
+package color
+
+type Color string
+
+const (
+	BlackBold   Color = "\033[30;1m"
+	RedBold     Color = "\033[31;1m"
+	GreenBold   Color = "\033[32;1m"
+	YellowBold  Color = "\033[33;1m"
+	BlueBold    Color = "\033[34;1m"
+	MagentaBold Color = "\033[35;1m"
+	CyanBold    Color = "\033[36;1m"
+	WhiteBold   Color = "\033[37;1m"
+	Black       Color = "\033[30m"
+	Red         Color = "\033[31m"
+	Green       Color = "\033[32m"
+	Yellow      Color = "\033[33m"
+	Blue        Color = "\033[34m"
+	Magenta     Color = "\033[35m"
+	Cyan        Color = "\033[36m"
+	White       Color = "\033[37m"
+)
+
+// ColorsList can be iterated over to easily pick a different color. This list
+// is intentionally setup for how colors appear in my terminal, it's easy to
+// pick your own!
+//
+// list := []Color{Red, Green, Blue}
+// for i := 0; ; i++{
+// 	col := list[i] % len(list)
+// }
+var ColorsList = []Color{
+	CyanBold,
+	GreenBold,
+	MagentaBold,
+	YellowBold,
+	BlueBold,
+}
+
+// Add the surrounding strings needed to colorize TTY outputs
+func (c Color) Add(in string) string {
+	if c == "" {
+		return in
+	}
+	return string(c) + in + "\033[0m"
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -37,14 +37,13 @@ Run "oneterminal example" to generate an example config file`,
 
 	generatedCommands := makeCommands(allConfigs)
 
-	for _, cmd := range generatedCommands {
-		rootCmd.AddCommand(cmd)
-	}
+	rootCmd.AddCommand(generatedCommands...)
 
 	rootCmd.AddCommand(ExampleCmd)
 	rootCmd.AddCommand(CompletionCmd)
 	rootCmd.AddCommand(makeUpdateCmd(version))
 	rootCmd.AddCommand(makeVersionCmd(version))
+	rootCmd.AddCommand(makeListCmd(allConfigs))
 
 	return rootCmd, nil
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1,10 +1,10 @@
 package cli
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/alexchao26/oneterminal/cmdsync"
+	"github.com/alexchao26/oneterminal/color"
 	"github.com/alexchao26/oneterminal/internal/yaml"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -50,19 +50,6 @@ Run "oneterminal example" to generate an example config file`,
 }
 
 func makeCommands(configs []yaml.OneTerminalConfig) []*cobra.Command {
-	ansiColors := []string{
-		"\033[36;1m", // intense cyan
-		"\033[32;1m", // intense green
-		"\033[35;1m", // intense magenta
-		"\033[34;1m", // intense blue
-		"\033[33;1m", // intense yellow
-		"\033[36m",   // cyan
-		"\033[32m",   // green
-		"\033[35m",   // magenta
-		"\033[34m",   // blue
-		"\033[33m",   // yellow
-	}
-
 	var cobraCommands []*cobra.Command
 
 	for _, config := range configs {
@@ -75,14 +62,12 @@ func makeCommands(configs []yaml.OneTerminalConfig) []*cobra.Command {
 			Long:  config.Long,
 			Run: func(cmd *cobra.Command, args []string) {
 				group := cmdsync.NewGroup()
-				var colorIndex int
 
-				for _, cmd := range config.Commands {
+				for i, cmd := range config.Commands {
 					var options []cmdsync.ShellCmdOption
 					if cmd.Name != "" {
-						options = append(options, cmdsync.CmdName(cmd.Name))
-						options = append(options, cmdsync.SetColor(ansiColors[colorIndex%len(ansiColors)]))
-						colorIndex++
+						options = append(options, cmdsync.Name(cmd.Name))
+						options = append(options, cmdsync.Color(color.ColorsList[i%len(color.ColorsList)]))
 					}
 					if cmd.CmdDir != "" {
 						options = append(options, cmdsync.CmdDir(cmd.CmdDir))
@@ -100,15 +85,15 @@ func makeCommands(configs []yaml.OneTerminalConfig) []*cobra.Command {
 						options = append(options, cmdsync.Environment(cmd.Environment))
 					}
 
-					c, err := cmdsync.NewShellCmd(config.Shell, cmd.Command, options...)
+					s, err := cmdsync.NewShellCmd(config.Shell, cmd.Command, options...)
 					if err != nil {
 						panic(fmt.Sprintf("error making command %q: %v", cmd.Name, err))
 					}
 
-					group.AddCommands(c)
+					group.AddCommands(s)
 				}
 
-				err := group.Run(context.Background())
+				err := group.Run()
 				if err != nil {
 					fmt.Printf("running %q: %v\n", config.Name, err)
 				}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -78,7 +78,7 @@ func makeCommands(configs []yaml.OneTerminalConfig) []*cobra.Command {
 				var colorIndex int
 
 				for _, cmd := range config.Commands {
-					var options []cmdsync.CmdOption
+					var options []cmdsync.ShellCmdOption
 					if cmd.Name != "" {
 						options = append(options, cmdsync.CmdName(cmd.Name))
 						options = append(options, cmdsync.SetColor(ansiColors[colorIndex%len(ansiColors)]))
@@ -100,7 +100,7 @@ func makeCommands(configs []yaml.OneTerminalConfig) []*cobra.Command {
 						options = append(options, cmdsync.Environment(cmd.Environment))
 					}
 
-					c, err := cmdsync.NewCmd(config.Shell, cmd.Command, options...)
+					c, err := cmdsync.NewShellCmd(config.Shell, cmd.Command, options...)
 					if err != nil {
 						panic(fmt.Sprintf("error making command %q: %v", cmd.Name, err))
 					}

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -1,0 +1,30 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/alexchao26/oneterminal/internal/yaml"
+	"github.com/spf13/cobra"
+)
+
+func makeListCmd(allConfigs []yaml.OneTerminalConfig) *cobra.Command {
+	return &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List only configured commands",
+		Long: `Lists the names of all commands configured in ~/.config/oneterminal/{file}.yaml
+
+Excludes built in commands.`,
+		Run: func(_ *cobra.Command, _ []string) {
+			fmt.Println("Configured commands (run via `oneterminal <name>`")
+			fmt.Println()
+			w := tabwriter.NewWriter(os.Stdout, 0, 8, 0, '\t', 0)
+			for _, config := range allConfigs {
+				fmt.Fprintf(w, "%s:\t%s\n", config.Name, config.Short)
+			}
+			w.Flush()
+		},
+	}
+}

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -24,6 +24,8 @@ so a local Go installation is required`,
 			// non-critical error, continue w/ update after logging
 			if err != nil {
 				fmt.Println(err)
+				// for running go install cmd
+				mostRecentVersion = "latest"
 			} else {
 				fmt.Printf("Most recent version is %s\n", mostRecentVersion)
 			}
@@ -50,8 +52,8 @@ so a local Go installation is required`,
 			}
 
 			// will error at c.Run if go is not installed locally
-			fmt.Println("Running `go install github.com/alexchao26/oneterminal@latest`")
-			c := exec.Command("go", "install", "github.com/alexchao26/oneterminal@latest")
+			fmt.Printf("Running `go install github.com/alexchao26/oneterminal@%s`\n", mostRecentVersion)
+			c := exec.Command("go", "install", fmt.Sprintf("github.com/alexchao26/oneterminal@%s", mostRecentVersion))
 			if err := c.Run(); err != nil {
 				fmt.Println("Error:", err)
 				return

--- a/internal/yaml/yaml.go
+++ b/internal/yaml/yaml.go
@@ -88,6 +88,8 @@ var reservedNames = map[string]bool{
 	"completion": true,
 	"example":    true,
 	"help":       true,
+	"list":       true,
+	"ls":         true,
 	"update":     true,
 }
 

--- a/internal/yaml/yaml.go
+++ b/internal/yaml/yaml.go
@@ -2,11 +2,10 @@ package yaml
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
-	"strings"
+	"regexp"
 
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
@@ -49,23 +48,28 @@ type Command struct {
 	Environment map[string]string `yaml:"environment,omitempty"`
 }
 
+var isYamlPattern = regexp.MustCompile(".ya?ml$")
+
 // ParseAllConfigs parses and returns configs in ~/.config/oneterminal
 func ParseAllConfigs() ([]OneTerminalConfig, error) {
 	// Unmarshal all values from configDir
 	var allConfigs []OneTerminalConfig
-	files, err := ioutil.ReadDir(configDir)
+	entries, err := os.ReadDir(configDir)
 	if err != nil {
 		return nil, errors.Wrap(err, "reading from config directory")
 	}
 
-	for _, f := range files {
-		if !strings.HasSuffix(f.Name(), ".yml") {
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		if !isYamlPattern.MatchString(e.Name()) {
 			continue
 		}
 
-		filename := path.Join(configDir, f.Name())
+		filename := path.Join(configDir, e.Name())
 
-		bytes, err := ioutil.ReadFile(filename)
+		bytes, err := os.ReadFile(filename)
 		if err != nil {
 			return nil, errors.Wrapf(err, "reading file %s", filename)
 		}
@@ -80,16 +84,16 @@ func ParseAllConfigs() ([]OneTerminalConfig, error) {
 	return allConfigs, nil
 }
 
+var reservedNames = map[string]bool{
+	"completion": true,
+	"example":    true,
+	"help":       true,
+	"update":     true,
+}
+
 // HasNameCollisions returns an error if multiple configs have the same name or
 // one of the reserved names (completion, example or help)
 func HasNameCollisions(configs []OneTerminalConfig) error {
-	reservedNames := map[string]bool{
-		"completion": true,
-		"example":    true,
-		"help":       true,
-		"update":     true,
-	}
-
 	allNames := make(map[string]bool)
 	for _, config := range configs {
 		if allNames[config.Name] {
@@ -145,7 +149,7 @@ Some say you can hear it from space.`,
 	}
 
 	// write to a file
-	err = ioutil.WriteFile(path.Join(configDir, filename), bytes, os.ModePerm)
+	err = os.WriteFile(path.Join(configDir, filename), bytes, os.ModePerm)
 	if err != nil {
 		return errors.Wrap(err, "writing to example config file")
 	}
@@ -156,7 +160,7 @@ Some say you can hear it from space.`,
 // MakeExampleConfigWithInstructions writes an example oneterminal yaml config
 // to ~/.config/oneterminal/example.yml with helpful comments
 func MakeExampleConfigWithInstructions(filename string) error {
-	err := ioutil.WriteFile(path.Join(configDir, filename), exampleConfig, os.ModePerm)
+	err := os.WriteFile(path.Join(configDir, filename), exampleConfig, os.ModePerm)
 	if err != nil {
 		return errors.Wrap(err, "writing to example config file")
 	}

--- a/internal/yaml/yaml_test.go
+++ b/internal/yaml/yaml_test.go
@@ -1,7 +1,6 @@
 package yaml
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -14,11 +13,10 @@ func setupTempDir(t *testing.T) {
 
 // testing utility function
 func getFileContents(t *testing.T, path string) string {
-	bytes, err := ioutil.ReadFile(path)
+	bytes, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("Reading file: %s; %v", path, err)
 	}
-
 	return string(bytes)
 }
 

--- a/oneterminal.go
+++ b/oneterminal.go
@@ -9,7 +9,7 @@ import (
 
 // variable is updated by goreleaser automatically but manually added here too
 // for manual/from source builds like `go get/install`
-var version = "0.3.5"
+var version = "0.4.0"
 
 func main() {
 	rootCmd, err := cli.Init(version)

--- a/oneterminal.go
+++ b/oneterminal.go
@@ -9,7 +9,7 @@ import (
 
 // variable is updated by goreleaser automatically but manually added here too
 // for manual/from source builds like `go get/install`
-var version = "0.3.4"
+var version = "0.3.5"
 
 func main() {
 	rootCmd, err := cli.Init(version)


### PR DESCRIPTION
- use os instead of ioutil per go116 changes
- !breaking: change Cmd to ShellCmd
- bug with replace all replacing -c flag
- update command uses the fetched version exactly b/c go mod mirror/proxy takes some time to update
- add RunContext method and call it from Run() w/ context.Background()
- refactor tty colors to a simple package a la zap logging pkg
- add list command to filter out built-in cmds
